### PR TITLE
Fix 'touched' method

### DIFF
--- a/tsc2004.py
+++ b/tsc2004.py
@@ -137,7 +137,7 @@ class TSC2004:
 
     @property
     def touched(self):
-        touching = self._read_register(_TSC2004_REG_CFR0) & (CFR0_PENMODE | CFR0_STATUS)
+        touching = self._read_register(_TSC2004_REG_CFR0) & CFR0_PENMODE
         return touching != 0
 
     @property


### PR DESCRIPTION
* Noticed the Arduino version of this driver had been updated with a fix for the 'touched' method behaving incorrectly. This commit applies the same fix to the CircuitPython version.